### PR TITLE
Set MySQL table-definition-cache to 2048

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     platform: linux/x86_64
     volumes:
       - .:/data
-    command: mysqld --datadir=/tmp/data --event-scheduler=ON
+    command: mysqld --datadir=/tmp/data --event-scheduler=ON --table-definition-cache=2048
     environment:
       MYSQL_ROOT_PASSWORD: toor
       MYSQL_DATABASE: fleet
@@ -43,7 +43,7 @@ services:
       FLEET_SERVER_ADDRESS: 0.0.0.0:8412
       FLEET_SERVER_CERT: /fleet/osquery/fleet.crt
       FLEET_SERVER_KEY: /fleet/osquery/fleet.key
-      FLEET_LOGGING_JSON: 'true'
+      FLEET_LOGGING_JSON: "true"
       FLEET_OSQUERY_STATUS_LOG_PLUGIN: filesystem
       FLEET_FILESYSTEM_STATUS_LOG_FILE: /logs/osqueryd.status.log
       FLEET_OSQUERY_RESULT_LOG_PLUGIN: filesystem
@@ -54,7 +54,7 @@ services:
       FLEET_VULNERABILITIES_CURRENT_INSTANCE_CHECKS: "yes"
       FLEET_VULNERABILITIES_DATABASES_PATH: /vulndb
       FLEET_VULNERABILITIES_PERIODICITY: 5m
-      FLEET_LOGGING_DEBUG: 'true'
+      FLEET_LOGGING_DEBUG: "true"
       # This can be configured for testing purposes but otherwise uses the
       # typical default of provided.
       FLEET_OSQUERY_HOST_IDENTIFIER: ${FLEET_OSQUERY_HOST_IDENTIFIER:-provided}
@@ -93,8 +93,8 @@ services:
       FLEET_MYSQL_PASSWORD: fleet
       FLEET_REDIS_ADDRESS: redis01:6379
       FLEET_SERVER_ADDRESS: 0.0.0.0:1337
-      FLEET_SERVER_TLS: 'false'
-      FLEET_LOGGING_JSON: 'true'
+      FLEET_SERVER_TLS: "false"
+      FLEET_LOGGING_JSON: "true"
       FLEET_SESSION_DURATION: 720h
       FLEET_OSQUERY_STATUS_LOG_PLUGIN: stdout
       FLEET_OSQUERY_RESULT_LOG_PLUGIN: stdout


### PR DESCRIPTION
Go tests are flaky because of this error: 

`Failing due to Error 1615 (HY000): Prepared statement needs to be re-prepared`

We believe increasing [table_definition_cache](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_table_definition_cache) will resolve it. 